### PR TITLE
Deserialize all empty tags as null by default

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -1,0 +1,2 @@
+env:
+  SKIP_VERSION_OVERRIDE_ON_BRANCH: 2.9.10-hubspot

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion> 
+  <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.fasterxml.jackson</groupId>
     <artifactId>jackson-base</artifactId>
@@ -8,7 +8,7 @@
   </parent>
   <groupId>com.fasterxml.jackson.dataformat</groupId>
   <artifactId>jackson-dataformat-xml</artifactId>
-  <version>2.9.10</version>
+  <version>2.9.10-hubspot-SNAPSHOT</version>
   <name>Jackson-dataformat-XML</name>
   <packaging>bundle</packaging>
   <description>Data format extension for Jackson (http://jackson.codehaus.org) to offer
@@ -20,7 +20,7 @@ Some data-binding types overridden as well (ObjectMapper sub-classed as XmlMappe
   <scm>
     <connection>scm:git:git@github.com:FasterXML/jackson-dataformat-xml.git</connection>
     <developerConnection>scm:git:git@github.com:FasterXML/jackson-dataformat-xml.git</developerConnection>
-    <url>http://github.com/FasterXML/jackson-dataformat-xml</url>    
+    <url>http://github.com/FasterXML/jackson-dataformat-xml</url>
     <tag>jackson-dataformat-xml-2.9.10</tag>
   </scm>
   <properties>
@@ -66,7 +66,7 @@ Some data-binding types overridden as well (ObjectMapper sub-classed as XmlMappe
       <artifactId>stax2-api</artifactId>
       <version>4.2</version>
     </dependency>
-    <!--  and a Stax impl is needed: SJSXP (from JDK 1.6) might work, but always   
+    <!--  and a Stax impl is needed: SJSXP (from JDK 1.6) might work, but always
           has odd issues. Let's default to Woodstox: caller can upgrade to Aalto
          (needs to block this dep)
       -->

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/XmlTokenStream.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/XmlTokenStream.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.core.JsonLocation;
 public class XmlTokenStream
 {
     // // // main token states:
-    
+
     public final static int XML_START_ELEMENT = 1;
     public final static int XML_END_ELEMENT = 2;
     public final static int XML_ATTRIBUTE_NAME = 3;
@@ -32,7 +32,7 @@ public class XmlTokenStream
     private final static int REPLAY_START_DUP = 1;
     private final static int REPLAY_END = 2;
     private final static int REPLAY_START_DELAYED = 3;
-    
+
     /*
     /**********************************************************************
     /* Configuration
@@ -49,7 +49,7 @@ public class XmlTokenStream
      * are enabled.
      */
     protected int _formatFeatures;
-    
+
     /*
     /**********************************************************************
     /* Parsing state
@@ -79,13 +79,13 @@ public class XmlTokenStream
     protected String _namespaceURI;
 
     protected String _textValue;
-    
+
     /*
     /**********************************************************************
     /* State for handling virtual wrapping
     /**********************************************************************
      */
-    
+
     /**
      * Flag used to indicate that given element should be "replayed".
      */
@@ -103,7 +103,7 @@ public class XmlTokenStream
      */
     protected String _nextLocalName;
     protected String _nextNamespaceURI;
-    
+
     /*
     /**********************************************************************
     /* Life-cycle
@@ -137,7 +137,7 @@ public class XmlTokenStream
     protected void setFormatFeatures(int f) {
         _formatFeatures = f;
     }
-    
+
     /*
     /**********************************************************************
     /* Public API
@@ -146,26 +146,26 @@ public class XmlTokenStream
 
     // DEBUGGING
     /*
-    public int next() throws IOException 
+    public int next() throws IOException
     {
         int n = next0();
         switch (n) {
-        case XML_START_ELEMENT: 
+        case XML_START_ELEMENT:
             System.out.println(" XML-token: XML_START_ELEMENT '"+_localName+"'");
             break;
-        case XML_END_ELEMENT: 
+        case XML_END_ELEMENT:
             System.out.println(" XML-token: XML_END_ELEMENT '"+_localName+"'");
             break;
-        case XML_ATTRIBUTE_NAME: 
+        case XML_ATTRIBUTE_NAME:
             System.out.println(" XML-token: XML_ATTRIBUTE_NAME '"+_localName+"'");
             break;
-        case XML_ATTRIBUTE_VALUE: 
+        case XML_ATTRIBUTE_VALUE:
             System.out.println(" XML-token: XML_ATTRIBUTE_VALUE '"+_textValue+"'");
             break;
-        case XML_TEXT: 
+        case XML_TEXT:
             System.out.println(" XML-token: XML_TEXT '"+_textValue+"'");
             break;
-        case XML_END: 
+        case XML_END:
             System.out.println(" XML-token: XML_END");
             break;
         default:
@@ -175,7 +175,7 @@ public class XmlTokenStream
     }
     */
 
-    public int next() throws XMLStreamException 
+    public int next() throws XMLStreamException
     {
         if (_repeatElement != 0) {
             return (_currentState = _handleRepeatElement());
@@ -199,7 +199,7 @@ public class XmlTokenStream
     public boolean hasAttributes() {
         return (_currentState == XML_START_ELEMENT) && (_attributeCount > 0);
     }
-    
+
     public void closeCompletely() throws XMLStreamException {
         _xmlReader.closeCompletely();
     }
@@ -221,16 +221,16 @@ public class XmlTokenStream
     /* Internal API: more esoteric methods
     /**********************************************************************
      */
-    
+
     /**
      * Method used to add virtual wrapping, which just duplicates START_ELEMENT
      * stream points to, and its matching closing element.
-     * 
+     *
      * @since 2.1
      */
     protected void repeatStartElement()
     {
-//System.out.println(" -> repeatStartElement for "+_localName);        
+//System.out.println(" -> repeatStartElement for "+_localName);
         // sanity check: can only be used when just returned START_ELEMENT:
         if (_currentState != XML_START_ELEMENT) {
             throw new IllegalStateException("Current state not XML_START_ELEMENT ("
@@ -248,7 +248,7 @@ public class XmlTokenStream
     /**
      * Method called to skip any attributes current START_ELEMENT may have,
      * so that they are not returned as token.
-     * 
+     *
      * @since 2.1
      */
     protected void skipAttributes()
@@ -388,17 +388,13 @@ public class XmlTokenStream
                 // 04-May-2018, tatu: We could easily make <tag></tag> ALSO report
                 //    as `null`, by below, but that breaks existing tests so not
                 //    done at least until 3.0.
-                /*
                 if (chars == null) {
                     if (FromXmlParser.Feature.EMPTY_ELEMENT_AS_NULL.enabledIn(_formatFeatures)) {
                         return null;
                     }
                     return "";
                 }
-                return chars;
-                */
-                return (chars == null) ? "" : chars.toString();
-
+                return chars.toString();
             // note: SPACE is ignorable (and seldom seen), not to be included
             case XMLStreamConstants.CHARACTERS:
             case XMLStreamConstants.CDATA:
@@ -455,7 +451,7 @@ public class XmlTokenStream
     /* Internal methods, other
     /**********************************************************************
      */
-    
+
     private final int _initStartElement() throws XMLStreamException
     {
         final String ns = _xmlReader.getNamespaceURI();
@@ -493,7 +489,7 @@ public class XmlTokenStream
      * Method called to handle details of repeating "virtual"
      * start/end elements, needed for handling 'unwrapped' lists.
      */
-    protected int _handleRepeatElement() throws XMLStreamException 
+    protected int _handleRepeatElement() throws XMLStreamException
     {
         int type = _repeatElement;
         _repeatElement = 0;
@@ -520,14 +516,14 @@ public class XmlTokenStream
             _namespaceURI = _nextNamespaceURI;
             _nextLocalName = null;
             _nextNamespaceURI = null;
-            
+
 //System.out.println("handleRepeat for START_DELAYED: "+_localName+" ("+_xmlReader.getLocalName()+")");
 
             return XML_START_ELEMENT;
         }
         throw new IllegalStateException("Unrecognized type to repeat: "+type);
     }
-    
+
     private final int _handleEndElement()
     {
         if (_currentWrapper != null) {
@@ -545,7 +541,7 @@ public class XmlTokenStream
         }
         return (_currentState = XML_END_ELEMENT);
     }
-    
+
     private JsonLocation _extractLocation(XMLStreamLocation2 location)
     {
         if (location == null) { // just for impls that might pass null...

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/deser/EmptyStringValueTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/deser/EmptyStringValueTest.java
@@ -37,7 +37,7 @@ public class EmptyStringValueTest extends XmlTestBase
                 Name.class);
         assertNotNull(name);
         assertEquals("Ryan", name.first);
-        assertEquals("", name.last);
+        assertNull(name.last);
     }
 
     public void testEmptyElement() throws Exception
@@ -47,7 +47,7 @@ public class EmptyStringValueTest extends XmlTestBase
         Name name = MAPPER.readValue(XML, Name.class);
         assertNotNull(name);
         assertNull(name.first);
-        assertEquals("", name.last);
+        assertNull(name.last);
 
         // but can be changed
         XmlMapper mapper2 = new XmlMapper();
@@ -65,7 +65,6 @@ public class EmptyStringValueTest extends XmlTestBase
         assertNotNull(bean);
         // empty String or null?
         // As per [dataformat-xml#162], really should be "", not null:
-        assertEquals("", bean.text);
-//        assertNull(bean.text);
+        assertNull(bean.text);
     }
 }

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/deser/SimpleStringValuesTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/deser/SimpleStringValuesTest.java
@@ -28,7 +28,7 @@ public class SimpleStringValuesTest extends XmlTestBase
      */
 
     private final XmlMapper MAPPER = new XmlMapper();
-    
+
     public void testSimpleStringElement() throws Exception
     {
         // first, simple one to verify baseline
@@ -51,7 +51,7 @@ public class SimpleStringValuesTest extends XmlTestBase
     /* Tests, with attributes
     /**********************************************************
      */
-    
+
     public void testStringWithAttribute() throws Exception
     {
         // and then the money shot: with 'standard' attribute...
@@ -73,7 +73,7 @@ public class SimpleStringValuesTest extends XmlTestBase
         assertEquals("abc", bean.a);
         assertEquals("def", bean.b);
     }
-    
+
     public void testStringArrayWithAttribute() throws Exception
     {
         // should even work for arrays of those
@@ -107,7 +107,7 @@ public class SimpleStringValuesTest extends XmlTestBase
     /* Tests, Lists
     /**********************************************************
      */
-    
+
     public void testStringsInList() throws Exception
     {
         Names input = new Names();
@@ -115,7 +115,7 @@ public class SimpleStringValuesTest extends XmlTestBase
         input.names.add(new Name("", ""));
         input.names.add(new Name("Sponge", "Bob"));
         String xml = MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(input);
-        
+
 //System.err.println("XML:\n"+xml);
 
         Names result = MAPPER.readValue(xml, Names.class);
@@ -125,6 +125,6 @@ public class SimpleStringValuesTest extends XmlTestBase
         assertEquals("Bob", result.names.get(2).last);
 
         // [dataformat-xml#162]: should get empty String, not null
-        assertEquals("", result.names.get(1).first);
+        assertNull(result.names.get(1).first);
     }
 }


### PR DESCRIPTION
Port of https://github.com/HubSpot/jackson-dataformat-xml/pull/1

This will cause `<key></key>` to deserialize as `null`.

[`?w=1`](https://github.com/HubSpot/jackson-dataformat-xml/pull/2/files?w=1)

@kmclarnon @Xcelled @jhaber 