### PR TITLE
[2.12.6] Deserialize all empty tags as null by default

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -1,0 +1,2 @@
+env:
+  SKIP_VERSION_OVERRIDE_ON_BRANCH: 2.12.6-hubspot

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
   <!-- that they should prefer consuming it instead. -->
   <!-- do_not_remove: published-with-gradle-metadata -->
-  <modelVersion>4.0.0</modelVersion> 
+  <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.fasterxml.jackson</groupId>
     <artifactId>jackson-base</artifactId>
@@ -13,7 +13,7 @@
   </parent>
   <groupId>com.fasterxml.jackson.dataformat</groupId>
   <artifactId>jackson-dataformat-xml</artifactId>
-  <version>2.12.6</version>
+  <version>2.12.6-hubspot-SNAPSHOT</version>
   <name>Jackson-dataformat-XML</name>
   <packaging>bundle</packaging>
   <description>Data format extension for Jackson to offer
@@ -23,7 +23,7 @@ alternative support for serializing POJOs as XML and deserializing XML as pojos.
   <scm>
     <connection>scm:git:git@github.com:FasterXML/jackson-dataformat-xml.git</connection>
     <developerConnection>scm:git:git@github.com:FasterXML/jackson-dataformat-xml.git</developerConnection>
-    <url>http://github.com/FasterXML/jackson-dataformat-xml</url>    
+    <url>http://github.com/FasterXML/jackson-dataformat-xml</url>
     <tag>jackson-dataformat-xml-2.12.6</tag>
   </scm>
   <properties>
@@ -77,9 +77,9 @@ alternative support for serializing POJOs as XML and deserializing XML as pojos.
 	  <groupId>javax.xml.stream</groupId>
 	  <artifactId>stax-api</artifactId>
         </exclusion>
-      </exclusions> 
+      </exclusions>
     </dependency>
-    <!--  and a Stax impl is needed: SJSXP (from JDK 1.6) might work, but always   
+    <!--  and a Stax impl is needed: SJSXP (from JDK 1.6) might work, but always
           has odd issues. Let's default to Woodstox: caller can upgrade to Aalto
          (needs to block this dep)
       -->
@@ -96,7 +96,7 @@ alternative support for serializing POJOs as XML and deserializing XML as pojos.
 	  <groupId>javax.xml.stream</groupId>
 	  <artifactId>stax-api</artifactId>
         </exclusion>
-      </exclusions> 
+      </exclusions>
     </dependency>
 
     <!-- 04-Feb-2018, tatu: Finally, Java 9 does not bundle JAXB, not even API;
@@ -127,6 +127,29 @@ alternative support for serializing POJOs as XML and deserializing XML as pojos.
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.sonatype.plugins</groupId>
+          <artifactId>nexus-staging-maven-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>injected-nexus-deploy</id>
+              <phase>never</phase>
+              <goals>
+                <goal>deploy</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
     <plugins>
       <plugin>
 	<groupId>org.jacoco</groupId>

--- a/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/XmlTokenStream.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/xml/deser/XmlTokenStream.java
@@ -68,7 +68,7 @@ public class XmlTokenStream
      * are enabled.
      */
     protected int _formatFeatures;
-    
+
     /*
     /**********************************************************************
     /* Parsing state
@@ -123,7 +123,7 @@ public class XmlTokenStream
     /* State for handling virtual wrapping
     /**********************************************************************
      */
-    
+
     /**
      * Flag used to indicate that given element should be "replayed".
      */
@@ -215,7 +215,7 @@ public class XmlTokenStream
     protected void setFormatFeatures(int f) {
         _formatFeatures = f;
     }
-    
+
     /*
     /**********************************************************************
     /* Public API
@@ -224,30 +224,30 @@ public class XmlTokenStream
 
     // DEBUGGING
     /*
-    public int next() throws XMLStreamException 
+    public int next() throws XMLStreamException
     {
         int n = next0();
         switch (n) {
-        case XML_START_ELEMENT: 
+        case XML_START_ELEMENT:
             System.out.printf(" XmlTokenStream.next(): XML_START_ELEMENT '%s' %s\n", _localName, _loc());
             break;
-        case XML_DELAYED_START_ELEMENT: 
+        case XML_DELAYED_START_ELEMENT:
             System.out.printf(" XmlTokenStream.next(): XML_DELAYED_START_ELEMENT '%s' %s\n", _localName, _loc());
             break;
-        case XML_END_ELEMENT: 
+        case XML_END_ELEMENT:
             // 24-May-2020, tatu: no name available for end element so do not print
             System.out.printf(" XmlTokenStream.next(): XML_END_ELEMENT %s\n", _loc());
             break;
-        case XML_ATTRIBUTE_NAME: 
+        case XML_ATTRIBUTE_NAME:
             System.out.printf(" XmlTokenStream.next(): XML_ATTRIBUTE_NAME '%s' %s\n", _localName, _loc());
             break;
-        case XML_ATTRIBUTE_VALUE: 
+        case XML_ATTRIBUTE_VALUE:
             System.out.printf(" XmlTokenStream.next(): XML_ATTRIBUTE_VALUE '%s' %s\n", _textValue, _loc());
             break;
-        case XML_TEXT: 
+        case XML_TEXT:
             System.out.printf(" XmlTokenStream.next(): XML_TEXT '%s' %s\n", _textValue, _loc());
             break;
-        case XML_END: 
+        case XML_END:
             System.out.printf(" XmlTokenStream.next(): XML_END %s\n", _loc());
             break;
         default:
@@ -330,7 +330,7 @@ public class XmlTokenStream
     /* Internal API: more esoteric methods
     /**********************************************************************
      */
-    
+
     /**
      * Method used to add virtual wrapping, which just duplicates START_ELEMENT
      * stream points to, and its matching closing element.
@@ -371,7 +371,7 @@ public class XmlTokenStream
     /**
      * Method called to skip any attributes current START_ELEMENT may have,
      * so that they are not returned as token.
-     * 
+     *
      * @since 2.1
      */
     protected void skipAttributes()
@@ -447,7 +447,7 @@ public class XmlTokenStream
                 }
                 _startElementAfterText = true;
                 _textValue = text;
-                
+
                 return (_currentState = XML_TEXT);
             }
             // For END_ELEMENT we will return text, if any
@@ -534,8 +534,13 @@ public class XmlTokenStream
 
             case XMLStreamConstants.END_ELEMENT:
             case XMLStreamConstants.END_DOCUMENT:
-                return (chars == null) ? "" : chars.toString();
-
+                if (chars != null) {
+                    return chars.toString();
+                } else if (FromXmlParser.Feature.EMPTY_ELEMENT_AS_NULL.enabledIn(_formatFeatures)) {
+                    return null;
+                } else {
+                    return "";
+                }
             // note: SPACE is ignorable (and seldom seen), not to be included
             case XMLStreamConstants.CHARACTERS:
             case XMLStreamConstants.CDATA:
@@ -694,7 +699,7 @@ public class XmlTokenStream
      * Method called to handle details of repeating "virtual"
      * start/end elements, needed for handling 'unwrapped' lists.
      */
-    protected int _handleRepeatElement() throws XMLStreamException 
+    protected int _handleRepeatElement() throws XMLStreamException
     {
 //System.out.println(" XMLTokenStream._handleRepeatElement()");
 
@@ -730,7 +735,7 @@ public class XmlTokenStream
         }
         throw new IllegalStateException("Unrecognized type to repeat: "+type);
     }
-    
+
     private final int _handleEndElement()
     {
 //System.out.println(" XMLTokenStream._handleEndElement()");

--- a/src/test/java/com/fasterxml/jackson/dataformat/xml/deser/EmptyStringValueTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/xml/deser/EmptyStringValueTest.java
@@ -47,7 +47,7 @@ public class EmptyStringValueTest extends XmlTestBase
 
         public Product427(@JsonProperty("stuff") Stuff427 s) { stuff = s; }
     }
-    
+
     /*
     /**********************************************************************
     /* Test methods
@@ -82,7 +82,7 @@ public class EmptyStringValueTest extends XmlTestBase
         name = mapper2.readValue(XML, Name.class);
         assertNotNull(name);
         assertNull(name.first);
-        assertEquals("", name.last);
+        assertNull(name.last);
     }
 
     public void testEmptyStringElement() throws Exception


### PR DESCRIPTION
Porting this to the newest version

@kmclarnon @Xcelled @snommit-mit @jhaber 